### PR TITLE
chore: update deploy job to depend on build and checks stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          # important - for analyze to work, it needs a deep clone of the repository
           fetch-depth: 0
 
       - name: Get workflow version
@@ -137,7 +136,7 @@ jobs:
       - name: Checkout (platform)
         uses: actions/checkout@v3
         with:
-          repository: jalantechnologies/github-ci
+          repository: caliyan/github-ci
           path: platform
           ref: ${{ steps.ci_workflow.outputs.version }}
 
@@ -168,7 +167,6 @@ jobs:
     steps:
       - name: Checkout (app)
         uses: actions/checkout@v3
-        # make sure to keep checked in code at different directory to avoid colliding with docker caching
         with:
           path: app
 
@@ -183,7 +181,7 @@ jobs:
       - name: Checkout (platform)
         uses: actions/checkout@v3
         with:
-          repository: jalantechnologies/github-ci
+          repository: caliyan/github-ci
           path: platform
           ref: ${{ steps.ci_workflow.outputs.version }}
 
@@ -218,7 +216,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     strategy:
-      # turn off fail fast, let all the checks run irrespective of failures
       fail-fast: false
       matrix:
         check: ${{ fromJSON(inputs.checks) }}
@@ -231,7 +228,7 @@ jobs:
       - name: Checkout (platform)
         uses: actions/checkout@v3
         with:
-          repository: jalantechnologies/github-ci
+          repository: caliyan/github-ci
           path: platform
           ref: ${{ needs.build.outputs.workflow_ci_version }}
 
@@ -250,7 +247,7 @@ jobs:
           docker_password: ${{ secrets.docker_password }}
 
   deploy:
-    needs: build
+    needs: [build, checks]
     runs-on: ubuntu-latest
     outputs:
       url: ${{ steps.deploy.outputs.url }}
@@ -263,7 +260,7 @@ jobs:
       - name: Checkout (platform)
         uses: actions/checkout@v3
         with:
-          repository: jalantechnologies/github-ci
+          repository: caliyan/github-ci
           path: platform
           ref: ${{ needs.build.outputs.workflow_ci_version }}
 
@@ -291,7 +288,6 @@ jobs:
           doppler_token: ${{ secrets.doppler_token }}
 
       - uses: marocchino/sticky-pull-request-comment@v2
-        # only run this step if enabled and pull request number was provided
         if: inputs.deploy_annotate_pr == true && inputs.pull_request_number
         with:
           header: ${{ inputs.app_name }}

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Checkout (platform)
         uses: actions/checkout@v3
         with:
-          repository: jalantechnologies/github-ci
+          repository: caliyan/github-ci   
           path: platform
           ref: ${{ steps.ci_workflow.outputs.version }}
 
@@ -108,7 +108,6 @@ jobs:
           DO_CLUSTER_ID: ${{ inputs.do_cluster_id }}
         if: "${{ env.DO_CLUSTER_ID != '' }}"
         run: doctl kubernetes cluster kubeconfig save $DO_CLUSTER_ID
-
 
       - name: AWS setup
         uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
**Why this changes require**
Previously, the pipeline was configured to run the deploy stage as long as the build stage succeeded. This caused an issue where, even if test cases failed, the deployment stage would still execute. As a result, deployments would fail unnecessarily and consume additional GitHub Actions minutes.

**Change Introduced**

- This update modifies the pipeline so that the deploy stage now depends on both the build and checks stages.
- Deployment will only run if both build and test cases pass.If test cases fail, the deploy stage will be skipped automatically, saving GitHub Actions minutes and avoiding unnecessary failed deployments.

**Manual Test Cases**

**1)PR with failing test cases**

- Raised a PR from the test branch with base branch namra/chore/ci-preview-deploy-conditions.
- Pipeline triggered → build succeeded → test cases failed.
- Result: Deploy stage was skipped, preventing wasted deployment runs.

<img width="1919" height="871" alt="Screenshot 2025-09-16 155956" src="https://github.com/user-attachments/assets/ef477ac5-82c8-42b7-9cea-e62edfea4c4d" />

**2)PR with passing the test cases**

Raised a PR from the test branch with base branch namra/chore/ci-preview-deploy-conditions.
Pipeline triggered → build succeeded → test cases passes.
Result: Deploy stage was executed succesfully as a result pipeline run succesfully .
<img width="1919" height="881" alt="Screenshot 2025-09-16 170104" src="https://github.com/user-attachments/assets/197ce985-d630-4b59-9416-8e9886003cac" />

**Changes Made in repo** 

**- In CI workflow file in deploy job along with build job i had add dependencies of checks also. There by deploy job will depend on both build and checks for triggering if any one fail deploy job will be skipped**

<img width="469" height="251" alt="image" src="https://github.com/user-attachments/assets/853f60ca-323e-4ec4-a314-807960ad71b3" />


**- updated the repository path  with caliya/github-ci to use that workflow instead of jalantechnologies/github-ci**

<img width="506" height="233" alt="image" src="https://github.com/user-attachments/assets/9859241f-6a4c-49d6-9611-d5c3b7e8abac" />

